### PR TITLE
1.2.8 - owh-domain-whois-rdap (Ajuste: Warning de produto + carregamento de script no Gutenberg)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: owh-domain-whois-rdap
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "1.2.7"
+  DEPLOY_TAG: "1.2.8"
 jobs:
   release-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: owh-domain-whois-rdap
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "1.2.7"
+  DEPLOY_TAG: "1.2.8"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.2.8 - 29/05/26
+* Ajuste: Warning de produto + carregamento de script no Gutenberg.
+
 # 1.2.7 - 27/05/26
 * NOVO: Banners.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * Tags: domínios, WHOIS, RDAP, verificação, DNS
 * Testado até: 6.8
 * Requer PHP: 7.4
-* Tag estável: 1.2.7
+* Tag estável: 1.2.8
 * Licença: GPLv2 ou posterior
 * URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/admin/class-owh-domain-whois-rdap-admin.php
+++ b/admin/class-owh-domain-whois-rdap-admin.php
@@ -292,8 +292,7 @@ class Owh_Domain_Whois_Rdap_Admin {
 			return;
 		}
 
-		// Enqueue block scripts
-		wp_enqueue_script(
+		wp_register_script(
 			'owh-rdap-blocks',
 			plugin_dir_url( __FILE__ ) . 'js/owh-domain-whois-rdap-blocks.js',
 			array( 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-editor', 'wp-components', 'wp-server-side-render' ),

--- a/owh-domain-whois-rdap.php
+++ b/owh-domain-whois-rdap.php
@@ -16,7 +16,7 @@
  * Plugin Name:       OWH Domain WHOIS RDAP
  * Plugin URI:        https://github.com/linknacional/owh-domain-whois-rdap
  * Description:       Verificação de disponibilidade de domínios via protocolo RDAP.
- * Version:           1.2.7
+ * Version:           1.2.8
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'OWH_DOMAIN_WHOIS_RDAP_VERSION', '1.2.7' );
+define( 'OWH_DOMAIN_WHOIS_RDAP_VERSION', '1.2.8' );
 
 /**
  * Plugin path and URL

--- a/public/class-owh-domain-whois-rdap-public.php
+++ b/public/class-owh-domain-whois-rdap-public.php
@@ -1474,8 +1474,10 @@ class Owh_Domain_Whois_Rdap_Public {
 				$normalized_payment_data = $payment_data;
 			}
 		} else {
-			// Fallback: use as-is
-			$normalized_payment_data = $payment_data;
+			// Fallback: cast objects to array; leave null/scalar as empty array (initialized above)
+			if ( is_object( $payment_data ) ) {
+				$normalized_payment_data = (array) $payment_data;
+			}
 		}
 		
 		foreach ( $normalized_payment_data as $key => $value ) {

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,9 @@ The plugin validates domains against IANA's official TLD list and supports stand
 Yes! Visit our [support page](https://www.linknacional.com.br/wordpress/plugins/) or create a GitHub issue for assistance.
 
 == Changelog ==
+= 1.2.8 - 2026/05/28 =
+* Fix: PHP warning on product + improper Gutenberg script loading.
+
 = 1.2.7 - 2026/05/27 =
 * NEW: Banners.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/plugins/
 Tags: domains, whois, rdap, search, dns
 Requires at least: 5.0
 Tested up to: 6.9
-Stable tag: 1.2.7
+Stable tag: 1.2.8
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt


### PR DESCRIPTION
# OWH Domain WHOIS RDAP

* Contribuidores: linknacional
* Link para doações: https://www.linknacional.com.br/wordpress/plugins/
* Tags: domínios, whois, rdap, busca, dns
* Testado até: 6.9
* Requer PHP: 7.4
* Tag estável: 1.2.8
* Licença: GPLv2 ou posterior
* URI da licença: https://www.gnu.org/licenses/gpl-2.0.html

## Descrição

Verificador avançado de disponibilidade de domínios utilizando o protocolo moderno RDAP para buscas rápidas e precisas.

### 🌐 **Busca de Domínios:**
- Verificação de disponibilidade em tempo real via protocolo RDAP
- Suporte a centenas de TLDs oficiais validados pela lista oficial da IANA
- Sistema de cache configurável para domínios disponíveis e indisponíveis
- Botão de compra configurável com URL de redirecionamento personalizada

### 🧱 **Bloco Gutenberg:**
- Bloco avançado com personalização visual completa (cores, tipografia, bordas)
- Opções de layout padrão e inline
- Suporte a CSS personalizado
- Compatível com o editor de blocos (Gutenberg)

### 🔧 **Personalização:**
Todas as funcionalidades podem ser configuradas pelo painel de configurações do admin. Consulte nossa seção de [Perguntas Frequentes (FAQ)](https://wordpress.org/support/plugin/owh-domain-whois-rdap/) para mais detalhes.

## 📥 Como instalar?

1. Acesse o painel de administração do WordPress e vá para **Plugins > Adicionar Novo**
2. Pesquise por "OWH Domain WHOIS RDAP"
3. Clique em **Instalar Agora** e depois em **Ativar**
4. **Pronto!** Acesse **OWH RDAP Settings** para configurar as páginas de busca e as opções do plugin

## 🔄 Fluxo de Desenvolvimento

Este plugin utiliza um fluxo de desenvolvimento automatizado com:
- **Análise de segurança** via CodeQL
- **Verificação de qualidade** via WordPress Plugin Check
- **Releases automatizados** com versionamento semântico
- **Testes de compatibilidade** em múltiplas versões do PHP

## 📋 Resumo da Versão 1.2.8

* Ajuste: Warning de produto + carregamento de script no Gutenberg.