### PR TITLE
1.2.10 - owh-domain-whois-rdap (Ajuste: Versão mínima do PHP requerida)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: owh-domain-whois-rdap
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "1.2.9"
+  DEPLOY_TAG: "1.2.10"
 jobs:
   release-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: owh-domain-whois-rdap
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "1.2.9"
+  DEPLOY_TAG: "1.2.10"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-$ 1.2.9 - 29/05/26
+# 1.2.10 - 01/06/26
+* Ajuste: Versão mínima do PHP requerida.
+
+# 1.2.9 - 29/05/26
 * Ajuste: Cálculo de frete e taxas no checkout.
 
 # 1.2.8 - 29/05/26

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * Tags: domínios, WHOIS, RDAP, verificação, DNS
 * Testado até: 6.8
 * Requer PHP: 7.4
-* Tag estável: 1.2.9
+* Tag estável: 1.2.10
 * Licença: GPLv2 ou posterior
 * URI da licença: [https://www.gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/owh-domain-whois-rdap.php
+++ b/owh-domain-whois-rdap.php
@@ -17,6 +17,7 @@
  * Plugin URI:        https://github.com/linknacional/owh-domain-whois-rdap
  * Description:       Verificação de disponibilidade de domínios via protocolo RDAP.
  * Version:           1.2.9
+ * Requires PHP:      8.2
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br
  * License:           GPL-2.0+
@@ -28,6 +29,23 @@
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
 	die;
+}
+
+/**
+ * Check minimum PHP version requirement.
+ */
+if ( version_compare( PHP_VERSION, '8.2', '<' ) ) {
+	add_action( 'admin_notices', function() {
+		echo '<div class="notice notice-error"><p>' .
+			sprintf(
+				/* translators: 1: required PHP version, 2: current PHP version */
+				esc_html__( 'OWH Domain WHOIS RDAP requires PHP %1$s or higher. Your server is running PHP %2$s.', 'owh-domain-whois-rdap' ),
+				'8.2',
+				PHP_VERSION
+			) .
+			'</p></div>';
+	} );
+	return;
 }
 
 /**

--- a/owh-domain-whois-rdap.php
+++ b/owh-domain-whois-rdap.php
@@ -16,7 +16,7 @@
  * Plugin Name:       OWH Domain WHOIS RDAP
  * Plugin URI:        https://github.com/linknacional/owh-domain-whois-rdap
  * Description:       Verificação de disponibilidade de domínios via protocolo RDAP.
- * Version:           1.2.9
+ * Version:           1.2.10
  * Requires PHP:      8.2
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br
@@ -53,7 +53,7 @@ if ( version_compare( PHP_VERSION, '8.2', '<' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'OWH_DOMAIN_WHOIS_RDAP_VERSION', '1.2.9' );
+define( 'OWH_DOMAIN_WHOIS_RDAP_VERSION', '1.2.10' );
 
 /**
  * Plugin path and URL

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: linknacional
 Donate link: https://www.linknacional.com.br/wordpress/plugins/
 Tags: domains, whois, rdap, search, dns
 Requires at least: 5.0
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 1.2.9
-Requires PHP: 7.4
+Requires PHP: 8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/plugins/
 Tags: domains, whois, rdap, search, dns
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 1.2.9
+Stable tag: 1.2.10
 Requires PHP: 8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,9 @@ The plugin validates domains against IANA's official TLD list and supports stand
 Yes! Visit our [support page](https://www.linknacional.com.br/wordpress/plugins/) or create a GitHub issue for assistance.
 
 == Changelog ==
+= 1.2.10 - 2026/06/01 =
+* Tweak: Minimum required PHP version bumped to 8.2.
+
 = 1.2.9 - 2026/05/28 =
 * Fix: Shipping and fees ignored in checkout total calculation.
 


### PR DESCRIPTION
# OWH Domain WHOIS RDAP

* Contribuidores: linknacional
* Link para doações: https://www.linknacional.com.br/wordpress/plugins/
* Tags: domínios, whois, rdap, busca, dns
* Testado até: 7.0
* Requer PHP: 8.2
* Tag estável: 1.2.10
* Licença: GPLv2 ou posterior
* URI da licença: https://www.gnu.org/licenses/gpl-2.0.html

## Descrição

Verificador avançado de disponibilidade de domínios utilizando o protocolo moderno RDAP para buscas rápidas e precisas.

### 🌐 **Busca de Domínios:**
- Verificação de disponibilidade em tempo real via protocolo RDAP
- Suporte a centenas de TLDs oficiais validados pela lista oficial da IANA
- Sistema de cache configurável para domínios disponíveis e indisponíveis
- Botão de compra configurável com URL de redirecionamento personalizada

### 🧱 **Bloco Gutenberg:**
- Bloco avançado com personalização visual completa (cores, tipografia, bordas)
- Opções de layout padrão e inline
- Suporte a CSS personalizado
- Compatível com o editor de blocos (Gutenberg)

### 🔧 **Personalização:**
Todas as funcionalidades podem ser configuradas pelo painel de configurações do admin. Consulte nossa seção de [Perguntas Frequentes (FAQ)](https://wordpress.org/support/plugin/owh-domain-whois-rdap/) para mais detalhes.

## 📥 Como instalar?

1. Acesse o painel de administração do WordPress e vá para **Plugins > Adicionar Novo**
2. Pesquise por "OWH Domain WHOIS RDAP"
3. Clique em **Instalar Agora** e depois em **Ativar**
4. **Pronto!** Acesse **OWH RDAP Settings** para configurar as páginas de busca e as opções do plugin

## 🔄 Fluxo de Desenvolvimento

Este plugin utiliza um fluxo de desenvolvimento automatizado com:
- **Análise de segurança** via CodeQL
- **Verificação de qualidade** via WordPress Plugin Check
- **Releases automatizados** com versionamento semântico
- **Testes de compatibilidade** em múltiplas versões do PHP

## 📋 Resumo da Versão 1.2.10

* Ajuste: Versão mínima do PHP requerida.